### PR TITLE
Improve markdown readability

### DIFF
--- a/Email-to-Action-Extractor-Audit.md
+++ b/Email-to-Action-Extractor-Audit.md
@@ -4,38 +4,38 @@ Theory is best understood through practice. To see how the principles from Secti
 
 ## Audit of the "Email-to-Action Extractor"
 
-1. Role & Mission: Executed Flawlessly
+1. **Role & Mission: Executed Flawlessly**
 
 The prompt immediately defines a clear, functional identity:
-ROLE
+**ROLE**
 You are an “Email-to-Action Extractor.”
 Given one email at a time, output an HTML block that reorganises the message into five cognitive buckets...
 
 Analysis: This is a perfect execution of the principle. The name, "Email-to-Action Extractor," is not a whimsical persona but a precise job title. The mission is unambiguous: ingest an email, reorganize it into five specific categories, and output an HTML block. The model knows exactly what it is and what it's supposed to deliver.
 
-2. Knowledge & Context: Defined by Limitation
+2. **Knowledge & Context: Defined by Limitation**
 
 The prompt expertly fences the model's knowledge base, forcing it to rely only on the provided text:
-TOOLING
+**TOOLING**
 No external tools required; work only with the email text passed in the user message.
-GLOBAL CONSTRAINTS
-✓ No hallucinations—use only content in the email.
+**GLOBAL CONSTRAINTS**
+- ✓ No hallucinations—use only content in the email.
 
 Analysis: This is a critical step for data-grounded tasks. By explicitly forbidding external tools and hallucinations, the prompt prevents the model from inventing facts or making assumptions. Its entire world is confined to the single email it is given, which is the most effective way to ensure the output is a faithful transformation of the input.
 
-3. Core Workflow: A Clear, Logical Sequence
+3. **Core Workflow: A Clear, Logical Sequence**
 
 The prompt outlines a non-negotiable, step-by-step process:
-WORKFLOW
-Scan the email.
-Populate each <ul> list...
-• Bullets in # Factual statements MUST be valid propositions...
-In # Micro-task plan, break the response into 3-to-7 atomic steps...
-Do not add commentary outside the prescribed HTML structure.
+**WORKFLOW**
+- Scan the email.
+- Populate each <ul> list...
+- • Bullets in # Factual statements MUST be valid propositions...
+- In # Micro-task plan, break the response into 3-to-7 atomic steps...
+- Do not add commentary outside the prescribed HTML structure.
 
 Analysis: This is a textbook implementation of the "Chain of Thought" principle. It forces the model to follow a logical procedure rather than attempting the task all at once. The micro-rule for "Factual statements" (must be true/false propositions) is a particularly advanced touch, adding a layer of logical rigor to the categorization task.
 
-4. Output Format & Structure: The Power of a Full Template
+4. **Output Format & Structure: The Power of a Full Template**
 
 This is where the prompt truly excels. It doesn't just describe the output format; it provides the entire HTML skeleton.
 <!-- ===== TEMPLATE START ===== -->
@@ -43,17 +43,17 @@ This is where the prompt truly excels. It doesn't just describe the output forma
 
 Analysis: Providing a complete, rigid template is the ultimate form of output control. The model's task is simplified from "create an HTML page" to "fill in the blanks of this specific template." By including the full structure, from <!DOCTYPE> to </html>, the prompt eliminates any chance of the model deviating from the desired format. This is a far more robust method than simply describing the structure in prose.
 
-5. Constraints & Guardrails: Airtight Rules
+5. **Constraints & Guardrails: Airtight Rules**
 
 The prompt uses a dedicated GLOBAL CONSTRAINTS section to enforce its most important rules:
-GLOBAL CONSTRAINTS
-✓ No hallucinations—use only content in the email.
-✓ Preserve the HTML skeleton; replace only the placeholder areas.
-✓ Do not output anything after the final </html> tag.
+**GLOBAL CONSTRAINTS**
+- ✓ No hallucinations—use only content in the email.
+- ✓ Preserve the HTML skeleton; replace only the placeholder areas.
+- ✓ Do not output anything after the final </html> tag.
 
 Analysis: These constraints are perfect examples of clear, enforceable rules. They cover the three main areas of potential failure: content (No hallucinations), format (Preserve the HTML skeleton), and technical validity (Do not output anything after the final </html> tag). The use of checkmarks and direct, imperative language makes these rules impossible for the model to misinterpret.
 
-6. Example (Few-Shot Prompt): A Perfect Demonstration
+6. **Example (Few-Shot Prompt): A Perfect Demonstration**
 
 The prompt includes a comprehensive, commented-out example that shows a complete input-to-output transformation:
 <!-- ===== MICRO-EXAMPLE ===== -->

--- a/SYSTEM_PROMPT_BLUEPRINT.md
+++ b/SYSTEM_PROMPT_BLUEPRINT.md
@@ -78,12 +78,14 @@ This section provides a universal template for constructing such prompts. It is 
 # --- END EXAMPLE ---
 ```
 
-Anatomy of the Blueprint
+### Anatomy of the Blueprint
+
 Each section of the template serves a critical function rooted in established prompt engineering best practices.
-1. ROLE & MISSION: This is the foundation. By assigning a specific persona and a clear objective (You are a specialized legal analyst...), you move the AI from a generalist model to a focused specialist. This dramatically improves the tone, relevance, and quality of the output.
-2. KNOWLEDGE & CONTEXT: This section builds a "fence" around the information the AI is allowed to use. Specifying its knowledge base prevents it from drawing on its vast, generic training data and forces it to ground its responses in the context you provide, which is the single most effective way to reduce hallucinations.
-3. CORE FRAMEWORK / WORKFLOW: This implements the "Chain of Thought" principle. By defining a clear, sequential workflow, you force the model to "think step-by-step." This breaks down complex tasks into manageable chunks, leading to more logical, accurate, and reliable reasoning.
-4. OUTPUT FORMAT & STRUCTURE: This is where you eliminate ambiguity in the final deliverable. Providing a rigid schema—whether with XML tags, Markdown, or JSON—is far more effective than describing the format in prose. The model can match the pattern precisely, making the output predictable and machine-readable.
-5. CONSTRAINTS & GUARDRAILS: This section sets the hard rules. Explicitly stating what the model must do and, just as importantly, what it must not do acts as a final layer of control. Negative constraints (DO NOT...) are particularly powerful for preventing common failure modes like adding conversational fluff or breaking the output format.
-6. EXAMPLE (FEW-SHOT PROMPT): This is arguably the most powerful component. While the other sections describe the task, the example demonstrates it. Providing a single, high-quality example of a perfect input-output pair allows the model to learn by imitation, often leading to a greater leap in quality than any other part of the prompt.
+
+1. **ROLE & MISSION**: This is the foundation. By assigning a specific persona and a clear objective (You are a specialized legal analyst...), you move the AI from a generalist model to a focused specialist. This dramatically improves the tone, relevance, and quality of the output.
+2. **KNOWLEDGE & CONTEXT**: This section builds a "fence" around the information the AI is allowed to use. Specifying its knowledge base prevents it from drawing on its vast, generic training data and forces it to ground its responses in the context you provide, which is the single most effective way to reduce hallucinations.
+3. **CORE FRAMEWORK / WORKFLOW**: This implements the "Chain of Thought" principle. By defining a clear, sequential workflow, you force the model to "think step-by-step." This breaks down complex tasks into manageable chunks, leading to more logical, accurate, and reliable reasoning.
+4. **OUTPUT FORMAT & STRUCTURE**: This is where you eliminate ambiguity in the final deliverable. Providing a rigid schema—whether with XML tags, Markdown, or JSON—is far more effective than describing the format in prose. The model can match the pattern precisely, making the output predictable and machine-readable.
+5. **CONSTRAINTS & GUARDRAILS**: This section sets the hard rules. Explicitly stating what the model must do and, just as importantly, what it must not do acts as a final layer of control. Negative constraints (DO NOT...) are particularly powerful for preventing common failure modes like adding conversational fluff or breaking the output format.
+6. **EXAMPLE (FEW-SHOT PROMPT)**: This is arguably the most powerful component. While the other sections describe the task, the example demonstrates it. Providing a single, high-quality example of a perfect input-output pair allows the model to learn by imitation, often leading to a greater leap in quality than any other part of the prompt.
 

--- a/prompt-engineering.md
+++ b/prompt-engineering.md
@@ -5,8 +5,8 @@ Prompt engineering, at its core, is the practice of designing effective instruct
 ## 1. Be Clear, Direct, and Specific
 
 The most fundamental principle is to eliminate ambiguity. Models like Claude perform best when instructions are direct and detailed. Instead of telling the model what not to do, it is more effective to provide affirmative instructions on what it should do.
-Ineffective (Vague): "Summarize the attached text."
-Effective (Specific): "Summarize the attached article in three bullet points, focusing on its financial implications. The target audience is a group of senior executives."
+- **Ineffective (Vague):** "Summarize the attached text."
+- **Effective (Specific):** "Summarize the attached article in three bullet points, focusing on its financial implications. The target audience is a group of senior executives."
 
 ## 2. Use XML Tags to Structure the Prompt
 
@@ -40,16 +40,16 @@ This makes the model's reasoning process transparent and forces a more deliberat
 
 One of the most powerful ways to guide a model is to provide examples of the desired output format and content. Providing three to five high-quality, relevant examples (a technique known as "few-shot prompting") helps the model understand patterns and replicate them accurately.
 Example: "Extract the company name and product from the following sentences. Follow the JSON format of the examples.
-Example 1:
-Text: "Innovate Inc. just launched the new TurboWidget."
-JSON: {"company": "Innovate Inc.", "product": "TurboWidget"}
-Text to analyze: ..."
+- **Example 1:**
+  - Text: "Innovate Inc. just launched the new TurboWidget."
+  - JSON: {"company": "Innovate Inc.", "product": "TurboWidget"}
+  - Text to analyze: ..."
 
 ## 6. Prefill the Model's Response
 
 Claude models can sometimes be "chatty," adding conversational filler before getting to the point (e.g., "Certainly, here is the summary you requested..."). To get a direct, clean output, you can use the Assistant turn to provide the very beginning of the expected response. This forces the model to continue directly from your provided text.
-User Prompt: ...Please provide the summary as a bulleted list.
-Assistant Prefill: *
+- **User Prompt:** ...Please provide the summary as a bulleted list.
+- **Assistant Prefill:** *
 By prefilling the first bullet point, you ensure the model's response begins immediately with the list, adhering strictly to the requested format.
 
 By combining these core techniques, a prompt engineer transforms a simple request into a robust, structured, and context-rich briefing that enables the AI to function as a reliable and highly specialized tool.


### PR DESCRIPTION
## Summary
- emphasize bullet points in Email-to-Action Extractor audit
- clarify blueprint section headings
- use lists and bold formatting in prompt-engineering guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867101128488332898637614ff3cd4d